### PR TITLE
Add simple variables editor

### DIFF
--- a/src/components/modals/VariablesEditorModal.tsx
+++ b/src/components/modals/VariablesEditorModal.tsx
@@ -3,7 +3,9 @@ import { Modal } from "@/components/Modal";
 import { FF7 } from "@/useFF7";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EditPopover } from "@/components/EditPopover";
+import SimpleVariables from "@/components/simple/SimpleVariables";
 
 interface VariablesEditorModalProps {
   isOpen: boolean;
@@ -15,6 +17,7 @@ type ViewFormat = "Decimal" | "Hex" | "Binary";
 
 export function VariablesEditorModal({ isOpen, setIsOpen, ff7 }: VariablesEditorModalProps) {
   const [selectedBank, setSelectedBank] = useState("1");
+  const [mode, setMode] = useState<'simple' | 'advanced'>('simple');
   const [variables, setVariables] = useState<number[]>([]);
   const [viewFormat, setViewFormat] = useState<ViewFormat>("Decimal");
   const [is16BitMode, setIs16BitMode] = useState(false);
@@ -165,80 +168,109 @@ export function VariablesEditorModal({ isOpen, setIsOpen, ff7 }: VariablesEditor
       size="lg"
       callback={() => {}}
     >
-      <div className="p-2 flex flex-col gap-2">
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-400">Bank:</span>
-            <Select value={selectedBank} onValueChange={handleBankChange}>
-              <SelectTrigger className="w-[100px] h-7 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {[1, 2, 3, 4, 5].map((bank) => (
-                  <SelectItem key={bank} value={bank.toString()} className="text-xs">
-                    Bank {bank} ({bankTitles[bank - 1]})
+      <Tabs value={mode} onValueChange={(v) => setMode(v as 'simple' | 'advanced')} className="w-full">
+        <TabsList className="w-full mb-2">
+          <TabsTrigger value="simple" className="flex-1">Simple</TabsTrigger>
+          <TabsTrigger value="advanced" className="flex-1">Advanced</TabsTrigger>
+        </TabsList>
+        <TabsContent value="simple" className="p-2">
+          <div className="flex items-center gap-4 mb-2">
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-slate-400">Bank:</span>
+              <Select value={selectedBank} onValueChange={handleBankChange}>
+                <SelectTrigger className="w-[100px] h-7 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {[1, 2, 3, 4, 5].map((bank) => (
+                    <SelectItem key={bank} value={bank.toString()} className="text-xs">
+                      Bank {bank} ({bankTitles[bank - 1]})
+                    </SelectItem>
+                  ))}
+                  <SelectItem key={6} value={"6"} className="text-xs">
+                    Temp Bank (5/6)
                   </SelectItem>
-                ))}
-                <SelectItem key={6} value={"6"} className="text-xs">
-                  Temp Bank (5/6)
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-400">View as:</span>
-            <Select value={viewFormat} onValueChange={(value: ViewFormat) => setViewFormat(value)}>
-              <SelectTrigger className="w-24 h-7 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="Decimal" className="text-xs">Decimal</SelectItem>
-                <SelectItem value="Hex" className="text-xs">Hex</SelectItem>
-                <SelectItem value="Binary" className="text-xs" disabled={is16BitMode}>Binary</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-400">16-bit mode:</span>
-            <Switch
-              checked={is16BitMode}
-              onCheckedChange={handle16BitModeChange}
-            />
-          </div>
-        </div>
-
-        <div className="grid grid-cols-4 gap-x-4 gap-y-1 max-h-[60vh] overflow-y-auto pr-2">
-          {getDisplayVariables().map((value, index) => (
-            <div key={index} className="contents">
-              <div 
-                className={`flex items-center gap-2 text-xs px-2 py-1 rounded-sm transition-colors duration-200 ${
-                  isChanged(index) 
-                    ? 'bg-yellow-500/25' 
-                    : 'bg-zinc-800/50'
-                } cursor-pointer hover:bg-zinc-700/50`}
-                data-trigger="true"
-                onClick={() => handleEdit(index)}
-              >
-                <EditPopover
-                  open={editIndex === index}
-                  onOpenChange={(open) => {
-                    if (!open) setEditIndex(null);
-                  }}
-                  value={editValue}
-                  onValueChange={setEditValue}
-                  onSubmit={handleSubmitEdit}
-                >
-                  <div className="flex items-center gap-2 flex-1">
-                    <span className="text-slate-400 w-6">#{is16BitMode ? index * 2 : index}</span>
-                    <span className="flex-1 font-mono">{formatValue(value, index)}</span>
-                  </div>
-                </EditPopover>
-              </div>
-              {index % 4 === 3 && <div className="col-span-4 h-px bg-zinc-800/50 -mx-2" />}
+                </SelectContent>
+              </Select>
             </div>
-          ))}
-        </div>
-      </div>
+          </div>
+          <SimpleVariables ff7={ff7} bank={parseInt(selectedBank)} variables={variables} reload={loadVariables} />
+        </TabsContent>
+        <TabsContent value="advanced" className="p-2">
+          <div className="flex items-center gap-4 mb-2">
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-slate-400">Bank:</span>
+              <Select value={selectedBank} onValueChange={handleBankChange}>
+                <SelectTrigger className="w-[100px] h-7 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {[1, 2, 3, 4, 5].map((bank) => (
+                    <SelectItem key={bank} value={bank.toString()} className="text-xs">
+                      Bank {bank} ({bankTitles[bank - 1]})
+                    </SelectItem>
+                  ))}
+                  <SelectItem key={6} value={"6"} className="text-xs">
+                    Temp Bank (5/6)
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-slate-400">View as:</span>
+              <Select value={viewFormat} onValueChange={(value: ViewFormat) => setViewFormat(value)}>
+                <SelectTrigger className="w-24 h-7 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="Decimal" className="text-xs">Decimal</SelectItem>
+                  <SelectItem value="Hex" className="text-xs">Hex</SelectItem>
+                  <SelectItem value="Binary" className="text-xs" disabled={is16BitMode}>Binary</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-slate-400">16-bit mode:</span>
+              <Switch
+                checked={is16BitMode}
+                onCheckedChange={handle16BitModeChange}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-4 gap-x-4 gap-y-1 max-h-[60vh] overflow-y-auto pr-2">
+            {getDisplayVariables().map((value, index) => (
+              <div key={index} className="contents">
+                <div
+                  className={`flex items-center gap-2 text-xs px-2 py-1 rounded-sm transition-colors duration-200 ${
+                    isChanged(index)
+                      ? 'bg-yellow-500/25'
+                      : 'bg-zinc-800/50'
+                  } cursor-pointer hover:bg-zinc-700/50`}
+                  data-trigger="true"
+                  onClick={() => handleEdit(index)}
+                >
+                  <EditPopover
+                    open={editIndex === index}
+                    onOpenChange={(open) => {
+                      if (!open) setEditIndex(null);
+                    }}
+                    value={editValue}
+                    onValueChange={setEditValue}
+                    onSubmit={handleSubmitEdit}
+                  >
+                    <div className="flex items-center gap-2 flex-1">
+                      <span className="text-slate-400 w-6">#{is16BitMode ? index * 2 : index}</span>
+                      <span className="flex-1 font-mono">{formatValue(value, index)}</span>
+                    </div>
+                  </EditPopover>
+                </div>
+                {index % 4 === 3 && <div className="col-span-4 h-px bg-zinc-800/50 -mx-2" />}
+              </div>
+            ))}
+          </div>
+        </TabsContent>
+      </Tabs>
     </Modal>
   );
 } 

--- a/src/components/simple/BitmaskField.tsx
+++ b/src/components/simple/BitmaskField.tsx
@@ -1,0 +1,35 @@
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { BitDefinition } from '@/data/saveBanks';
+
+interface BitmaskFieldProps {
+  label: string;
+  value: number;
+  bits: BitDefinition[];
+  onChange: (value: number) => Promise<void> | void;
+}
+
+export default function BitmaskField({ label, value, bits, onChange }: BitmaskFieldProps) {
+  const handleToggle = async (mask: number, checked: boolean) => {
+    let newVal = value;
+    if (checked) newVal |= mask; else newVal &= ~mask;
+    await onChange(newVal);
+  };
+
+  return (
+    <div className="py-2">
+      <Label className="text-xs font-medium">{label}</Label>
+      <div className="ml-2 mt-1 flex flex-col gap-1">
+        {bits.map(bit => (
+          <label key={bit.mask} className="flex items-center gap-2 text-xs">
+            <Checkbox
+              checked={Boolean(value & bit.mask)}
+              onCheckedChange={(checked) => handleToggle(bit.mask, !!checked)}
+            />
+            <span>{bit.label}</span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/simple/NumericField.tsx
+++ b/src/components/simple/NumericField.tsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+import { Label } from '@/components/ui/label';
+import { EditPopover } from '@/components/EditPopover';
+
+interface NumericFieldProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => Promise<void> | void;
+}
+
+export default function NumericField({ label, value, onChange }: NumericFieldProps) {
+  const [open, setOpen] = useState(false);
+  const [editValue, setEditValue] = useState(String(value));
+
+  useEffect(() => {
+    setEditValue(String(value));
+  }, [value]);
+
+  const handleSubmit = async () => {
+    const num = parseInt(editValue);
+    if (!isNaN(num)) {
+      await onChange(num);
+    }
+    setOpen(false);
+  };
+
+  return (
+    <div className="flex items-center justify-between py-1 text-xs cursor-pointer hover:text-primary" onClick={() => setOpen(true)}>
+      <Label className="mr-2">{label}</Label>
+      <EditPopover
+        open={open}
+        onOpenChange={setOpen}
+        value={editValue}
+        onValueChange={setEditValue}
+        onSubmit={handleSubmit}
+      >
+        <span data-trigger="true">{value}</span>
+      </EditPopover>
+    </div>
+  );
+}

--- a/src/components/simple/SimpleVariables.tsx
+++ b/src/components/simple/SimpleVariables.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import NumericField from './NumericField';
+import BitmaskField from './BitmaskField';
+import { banks, SaveVarDefinition } from '@/data/saveBanks';
+import { Input } from '@/components/ui/input';
+import { FF7 } from '@/useFF7';
+
+interface SimpleVariablesProps {
+  ff7: FF7;
+  bank: number;
+  variables: number[];
+  reload: () => Promise<void>;
+}
+
+export default function SimpleVariables({ ff7, bank, variables, reload }: SimpleVariablesProps) {
+  const defs = banks[bank];
+  const [search, setSearch] = useState('');
+  if (!defs) {
+    return <div className="text-xs">No definitions for this bank.</div>;
+  }
+
+  const getValue = (def: SaveVarDefinition) => {
+    if (def.length === 1) return variables[def.offset] || 0;
+    const low = variables[def.offset] || 0;
+    const high = variables[def.offset + 1] || 0;
+    return low + (high << 8);
+  };
+
+  const setValue = async (def: SaveVarDefinition, value: number) => {
+    if (def.length === 1) {
+      await ff7.setVariable(bank, def.offset, value & 0xff);
+    } else {
+      await ff7.setVariable16(bank, def.offset, value & 0xffff);
+    }
+    await reload();
+  };
+
+  const filtered = defs.filter(d => d.label.toLowerCase().includes(search.toLowerCase()));
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Input
+        className="sticky top-0 z-10"
+        placeholder="Search..."
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+      />
+      <div className="max-h-[60vh] overflow-y-auto pr-2 mt-2 flex flex-col gap-3">
+        {filtered.map(def => {
+          const val = getValue(def);
+          if (def.type === 'bitmask' && def.bits) {
+            return (
+              <BitmaskField
+                key={def.offset}
+                label={def.label}
+                value={val}
+                bits={def.bits}
+                onChange={v => setValue(def, v)}
+              />
+            );
+          }
+          return (
+            <NumericField
+              key={def.offset}
+              label={def.label}
+              value={val}
+              onChange={v => setValue(def, v)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/data/saveBanks.ts
+++ b/src/data/saveBanks.ts
@@ -1,0 +1,172 @@
+export interface BitDefinition {
+  mask: number;
+  label: string;
+}
+
+export type VarType = 'u8' | 'u16' | 'bitmask';
+
+export interface SaveVarDefinition {
+  offset: number;
+  length: number; // bytes
+  type: VarType;
+  label: string;
+  bits?: BitDefinition[];
+}
+
+export const bank1Fields: SaveVarDefinition[] = [
+  { offset: 0, length: 2, type: 'u16', label: 'Main progress' },
+  { offset: 2, length: 1, type: 'u8', label: "Yuffie's initial level" },
+  { offset: 3, length: 1, type: 'u8', label: "Aeris love points" },
+  { offset: 4, length: 1, type: 'u8', label: "Tifa love points" },
+  { offset: 5, length: 1, type: 'u8', label: "Yuffie love points" },
+  { offset: 6, length: 1, type: 'u8', label: "Barret love points" },
+  { offset: 7, length: 1, type: 'u8', label: 'Temp party member 1' },
+  { offset: 8, length: 1, type: 'u8', label: 'Temp party member 2' },
+  { offset: 9, length: 1, type: 'u8', label: 'Temp party member 3' },
+  { offset: 16, length: 1, type: 'u8', label: 'Game timer hours' },
+  { offset: 17, length: 1, type: 'u8', label: 'Game timer minutes' },
+  { offset: 18, length: 1, type: 'u8', label: 'Game timer seconds' },
+  { offset: 19, length: 1, type: 'u8', label: 'Game timer frames' },
+  { offset: 20, length: 1, type: 'u8', label: 'Countdown hours' },
+  { offset: 21, length: 1, type: 'u8', label: 'Countdown minutes' },
+  { offset: 22, length: 1, type: 'u8', label: 'Countdown seconds' },
+  { offset: 23, length: 1, type: 'u8', label: 'Countdown frames' },
+  { offset: 24, length: 2, type: 'u16', label: 'Battles fought' },
+  { offset: 26, length: 2, type: 'u16', label: 'Escapes' },
+  {
+    offset: 28,
+    length: 2,
+    type: 'bitmask',
+    label: 'Menu visibility',
+    bits: [
+      { mask: 0x1, label: 'Item' },
+      { mask: 0x2, label: 'Magic' },
+      { mask: 0x4, label: 'Materia' },
+      { mask: 0x8, label: 'Equip' },
+      { mask: 0x10, label: 'Status' },
+      { mask: 0x20, label: 'Order' },
+      { mask: 0x40, label: 'Limit' },
+      { mask: 0x80, label: 'Config' },
+      { mask: 0x100, label: 'PHS' },
+      { mask: 0x200, label: 'Save' },
+    ],
+  },
+  {
+    offset: 30,
+    length: 2,
+    type: 'bitmask',
+    label: 'Menu lock',
+    bits: [
+      { mask: 0x1, label: 'Item' },
+      { mask: 0x2, label: 'Magic' },
+      { mask: 0x4, label: 'Materia' },
+      { mask: 0x8, label: 'Equip' },
+      { mask: 0x10, label: 'Status' },
+      { mask: 0x20, label: 'Order' },
+      { mask: 0x40, label: 'Limit' },
+      { mask: 0x80, label: 'Config' },
+      { mask: 0x100, label: 'PHS' },
+      { mask: 0x200, label: 'Save' },
+    ],
+  },
+  {
+    offset: 36,
+    length: 1,
+    type: 'bitmask',
+    label: 'Train Graveyard items',
+    bits: [
+      { mask: 0x01, label: 'Hi-Potion (Barrel 1)' },
+      { mask: 0x02, label: 'Echo Screen (Barrel 2)' },
+      { mask: 0x04, label: 'Potion (Floor 2)' },
+      { mask: 0x08, label: 'Ether (Floor 3)' },
+      { mask: 0x10, label: 'Hi-Potion (Roof Train 1)' },
+      { mask: 0x20, label: 'Potion (Inside Train 2)' },
+      { mask: 0x40, label: 'Potion (Floor 1)' },
+      { mask: 0x80, label: 'Hi-Potion (Roof Train 2)' },
+    ],
+  },
+  {
+    offset: 37,
+    length: 1,
+    type: 'bitmask',
+    label: 'Field items 1',
+    bits: [
+      { mask: 0x01, label: 'Elixir' },
+      { mask: 0x02, label: 'Potion' },
+      { mask: 0x04, label: 'Safety Bit' },
+      { mask: 0x08, label: 'Mind Source' },
+      { mask: 0x10, label: 'Sneak Glove' },
+      { mask: 0x20, label: 'Premium Heart' },
+      { mask: 0x40, label: 'Unused 1' },
+      { mask: 0x80, label: 'Unused 2' },
+    ],
+  },
+  {
+    offset: 48,
+    length: 1,
+    type: 'bitmask',
+    label: 'Field items / materia',
+    bits: [
+      { mask: 0x01, label: 'Potion' },
+      { mask: 0x02, label: 'Potion + Phoenix Down' },
+      { mask: 0x04, label: 'Ether' },
+      { mask: 0x08, label: 'Cover materia' },
+      { mask: 0x10, label: 'Choco-Mog summon' },
+      { mask: 0x20, label: 'Sense materia' },
+      { mask: 0x40, label: 'Ramuh summon' },
+      { mask: 0x80, label: 'Mythril key' },
+    ],
+  },
+  {
+    offset: 49,
+    length: 1,
+    type: 'bitmask',
+    label: 'Materia cave items',
+    bits: [
+      { mask: 0x01, label: 'Mime materia' },
+      { mask: 0x02, label: 'HP<->MP materia' },
+      { mask: 0x04, label: 'Quadra Magic' },
+      { mask: 0x08, label: 'Knights of the Round' },
+      { mask: 0x10, label: 'Elixir' },
+      { mask: 0x20, label: 'X-Potion' },
+      { mask: 0x40, label: 'Turbo Ether' },
+      { mask: 0x80, label: 'Vaccine' },
+    ],
+  },
+  {
+    offset: 50,
+    length: 1,
+    type: 'bitmask',
+    label: 'Northern Cave items 1',
+    bits: [
+      { mask: 0x01, label: 'Magic Counter materia' },
+      { mask: 0x02, label: 'Speed Source' },
+      { mask: 0x04, label: 'Turbo Ether (2)' },
+      { mask: 0x08, label: 'X-Potion (2)' },
+      { mask: 0x10, label: 'Mega All' },
+      { mask: 0x20, label: 'Luck Source' },
+      { mask: 0x40, label: 'Remedy' },
+      { mask: 0x80, label: 'Bolt Ring' },
+    ],
+  },
+  {
+    offset: 51,
+    length: 1,
+    type: 'bitmask',
+    label: 'Northern Cave items 2',
+    bits: [
+      { mask: 0x01, label: 'Gold Armlet' },
+      { mask: 0x02, label: 'Great Gospel' },
+      { mask: 0x04, label: 'Umbrella prize' },
+      { mask: 0x08, label: 'Flayer prize' },
+      { mask: 0x10, label: 'Death Penalty + Chaos' },
+      { mask: 0x20, label: 'Elixir (2)' },
+      { mask: 0x40, label: 'Enemy Skill animation' },
+      { mask: 0x80, label: 'Enemy Skill materia' },
+    ],
+  },
+];
+
+export const banks = {
+  1: bank1Fields,
+};


### PR DESCRIPTION
## Summary
- create data file for Bank1 variable definitions
- add components to display/edit numeric and bitmask variables
- integrate new "Simple" tab into Variables editor

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841bfdbe9708324aea8f626739366c3